### PR TITLE
KAN-71 Remove ebs-csi-driver addons

### DIFF
--- a/eks/main.tf
+++ b/eks/main.tf
@@ -69,11 +69,6 @@ module "eks" {
       version              = "v1.10.1-eksbuild.1"
       configuration_values = jsonencode({})
 
-    },
-    {
-      name                 = "aws-ebs-csi-driver"
-      version              = "v1.25.0-eksbuild.1"
-      configuration_values = jsonencode({})
     }
   ]
 


### PR DESCRIPTION
설치속도가 너무 느려 ebs-csi-driver 애드온을 제거합니다. helm Chart로 대체할 예정입니다.