### PR TITLE
Change argocd installation

### DIFF
--- a/argocd_bootstrap/argocd/README.md
+++ b/argocd_bootstrap/argocd/README.md
@@ -24,6 +24,14 @@ spec:
 
 ## kustomize로 설치
 
+1. argocd namespace 생성
+
+```sh
+kubectl create ns argocd
+```
+
+2. kusotmize 배포
+
 ```bash
 kubectl kustomize ./ | kubectl apply -f -
 ```

--- a/argocd_bootstrap/argocd/kustomization.yaml
+++ b/argocd_bootstrap/argocd/kustomization.yaml
@@ -3,7 +3,6 @@ kind: Kustomization
 namespace: argocd
 
 resources:
-- ./namespace.yaml
 - github.com/argoproj/argo-cd/manifests/base?ref=stable
 - github.com/argoproj/argo-cd/manifests/crds?ref=stable
 - github.com/argoproj/argo-cd/manifests/cluster-rbac?ref=stable

--- a/argocd_bootstrap/argocd/namespace.yaml
+++ b/argocd_bootstrap/argocd/namespace.yaml
@@ -1,4 +1,0 @@
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: argocd


### PR DESCRIPTION
안전하게 ArgoCD를 삭제하기 위해, Argocd 설치 kustomize에서 namespace를 제외시킵니다.