### PR TITLE
#85 Fix EKS managed node group about stroage

### DIFF
--- a/eks/module/eks/node_group.tf
+++ b/eks/module/eks/node_group.tf
@@ -6,7 +6,6 @@ resource "aws_eks_node_group" "main" {
   instance_types  = each.value["instance_types"]
   capacity_type   = each.value["capacity_type"]
   release_version = each.value["release_version"]
-  disk_size       = each.value["disk_size"]
   node_role_arn   = aws_iam_role.node_group_role.arn
   subnet_ids      = var.private_subnets_ids
 


### PR DESCRIPTION
- EKS 모듈에서 Managed nodegroup의 storage 설정 오류를 수정합니다.
- 이전 [PR](https://github.com/choisungwook/terraform_practice/pull/86)에서 launch template을 설정했기 때문에, 기존 스토리지 설정과 충돌이 났습니다. 기존 스토리지 설정을 삭제하니 오류가 해결되었습니다.