### PR TITLE
feat: enhance user data generation for custom AMIs in launch template

### DIFF
--- a/eks/module/eks/node_group.tf
+++ b/eks/module/eks/node_group.tf
@@ -55,7 +55,29 @@ resource "aws_launch_template" "node_group" {
   # (optional) AMI_ID
   image_id = each.value.ami_id
 
-  user_data = each.value["user_data"]
+  # 커스텀 AMI 사용 시 NodeConfig user data를 자동 생성
+  # managed node group은 커스텀 AMI + launch template 조합에서 user data를 자동 주입하지 않음
+  # NodeConfig는 모듈이 항상 생성하고, 사용자 user_data가 있으면 MIME 파트로 병합
+  user_data = each.value.ami_id != null ? base64encode(join("\n", compact([
+    "MIME-Version: 1.0",
+    "Content-Type: multipart/mixed; boundary=\"BOUNDARY\"",
+    "",
+    "--BOUNDARY",
+    "Content-Type: application/node.eks.aws",
+    "",
+    "---",
+    "apiVersion: node.eks.aws/v1alpha1",
+    "kind: NodeConfig",
+    "spec:",
+    "  cluster:",
+    "    name: ${aws_eks_cluster.main.name}",
+    "    apiServerEndpoint: ${aws_eks_cluster.main.endpoint}",
+    "    certificateAuthority: ${aws_eks_cluster.main.certificate_authority[0].data}",
+    "    cidr: ${aws_eks_cluster.main.kubernetes_network_config[0].service_ipv4_cidr}",
+    "",
+    each.value["user_data"] != null ? "--BOUNDARY\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\n\n${each.value["user_data"]}" : "",
+    "--BOUNDARY--",
+  ]))) : each.value["user_data"]
 
   block_device_mappings {
     device_name = "/dev/xvda"


### PR DESCRIPTION
eks custom ami를 사용할 때, managed node group가 생성한 EC2인스턴스가 EKS cluster에 조인할 수 있도록 nodeconfig를 추가합니다. 또한, 사용자가 전달한 userdata도 실행될 수 있도록 레이어구조(user data 병합)를 가지게 합니다.