### PR TITLE
fix: correct user data generation for custom AMIs in launch template

### DIFF
--- a/eks/module/eks/node_group.tf
+++ b/eks/module/eks/node_group.tf
@@ -58,7 +58,7 @@ resource "aws_launch_template" "node_group" {
   # 커스텀 AMI 사용 시 NodeConfig user data를 자동 생성
   # managed node group은 커스텀 AMI + launch template 조합에서 user data를 자동 주입하지 않음
   # NodeConfig는 모듈이 항상 생성하고, 사용자 user_data가 있으면 MIME 파트로 병합
-  user_data = each.value.ami_id != null ? base64encode(join("\n", compact([
+  user_data = each.value.ami_id != null ? base64encode(join("\n", [
     "MIME-Version: 1.0",
     "Content-Type: multipart/mixed; boundary=\"BOUNDARY\"",
     "",
@@ -77,7 +77,7 @@ resource "aws_launch_template" "node_group" {
     "",
     each.value["user_data"] != null ? "--BOUNDARY\nContent-Type: text/x-shellscript; charset=\"us-ascii\"\n\n${each.value["user_data"]}" : "",
     "--BOUNDARY--",
-  ]))) : each.value["user_data"]
+  ])) : each.value["user_data"]
 
   block_device_mappings {
     device_name = "/dev/xvda"


### PR DESCRIPTION
managed nodegroup이 사용하는 userdata yaml 파싱오류를 수정합니다.